### PR TITLE
Got Ant build errors due to 'includeantruntime'

### DIFF
--- a/ccgbank/bin/ner/build-ner-api.xml
+++ b/ccgbank/bin/ner/build-ner-api.xml
@@ -33,7 +33,7 @@
   
   <target name="compile-ner-app" depends="init">
     <echo message="classpath ${stanford.core.nlp}"/>
-    <javac classpath="${stanford.core.nlp}" srcdir="./NERApp/src/" destdir="./NERApp/src/"/>
+    <javac includeantruntime="false" classpath="${stanford.core.nlp}" srcdir="./NERApp/src/" destdir="./NERApp/src/"/>
   </target>
 
   <target name="jar-ner-app" depends="compile-ner-app">


### PR DESCRIPTION
Getting parsing set up again, decided to get the NERApp running with updated Stanford Core NLP.

When I tried to build the NERApp, I got an error like `warning: 'includeantruntime' was not set, 
defaulting to build.sysclasspath=last; set to false for repeatable builds`.

Googling revealed this StackOverflow answer, suggesting this is a 'misfeature' introduced in Ant 1.8: https://stackoverflow.com/questions/5103384/ant-warning-includeantruntime-was-not-set/5103432#5103432

I used the suggested fix, altering the call to javac in the build file to get the build working (against an older version of Stanford Core NLP; see my other PR for the updated NERApp).