### PR TITLE
Update NERApp to be compatible with current Stanford Core NLP

### DIFF
--- a/ccgbank/bin/ner/NERApp/src/nerapp/NERApp.java
+++ b/ccgbank/bin/ner/NERApp/src/nerapp/NERApp.java
@@ -54,38 +54,38 @@ public class NERApp {
       for(String classMod : classifierMods) { if(classMod != null) { numClassifiers++; } }
       switch (numClassifiers) {
           case 1:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0]);
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0]);
 	      break;
           case 2:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1]);
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1]);
 	      break;
           case 3:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2]);
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2]);
 	      break;
           case 4:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3]);
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3]);
 	      break;
           case 5:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4]);
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4]);
 	      break;
           case 6:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
 						     classifierMods[5]);
 	      break;
           case 7:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
 						     classifierMods[5], classifierMods[6]);
 	      break;
           case 8:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
 						     classifierMods[5], classifierMods[6], classifierMods[7]);
 	      break;
           case 9:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
 						     classifierMods[5], classifierMods[6], classifierMods[7], classifierMods[8]);
 	      break;
           case 10:
-	      classifier = new NERClassifierCombiner(true, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
+	      classifier = new NERClassifierCombiner(true, false, false, classifierMods[0], classifierMods[1], classifierMods[2], classifierMods[3], classifierMods[4],
 						     classifierMods[5], classifierMods[6], classifierMods[7], classifierMods[8], classifierMods[9]);
 	      break;
           default:

--- a/ccgbank/bin/ner/build-ner-api.xml
+++ b/ccgbank/bin/ner/build-ner-api.xml
@@ -33,7 +33,7 @@
   
   <target name="compile-ner-app" depends="init">
     <echo message="classpath ${stanford.core.nlp}"/>
-    <javac classpath="${stanford.core.nlp}" srcdir="./NERApp/src/" destdir="./NERApp/src/"/>
+    <javac includeantruntime="false" classpath="${stanford.core.nlp}" srcdir="./NERApp/src/" destdir="./NERApp/src/"/>
   </target>
 
   <target name="jar-ner-app" depends="compile-ner-app">


### PR DESCRIPTION
The constructor we were using now requires an additional arg.

Not doing anything clever or changing behavior, just added in 'false' for the new arg.

See the current version of NERClassifierCombiner.java to see the affected methods: https://github.com/stanfordnlp/CoreNLP/blob/master/src/edu/stanford/nlp/ie/NERClassifierCombiner.java#L103 (and the same method def in Stanford Core NLP v. 1.3.4 if you're interested).

Also, looks like this branch ended up including my patch for the 'includeantruntime' problem in the build file--sorry!