### PR TITLE
Adding -prompt flag to WebCCG

### DIFF
--- a/src/opennlp/ccg/WebCCG.java
+++ b/src/opennlp/ccg/WebCCG.java
@@ -52,10 +52,11 @@ import java.util.*;
  */
 public class WebCCG {
     /** Main method for tccg. */
-    public static void main(String[] args) throws IOException, LexException { 
-	String usage = "java opennlp.ccg.WebCCG " + 
-"[-showall] [-showderivs] [-showsem] [-showfeats] [-visualize FILE] GRAMMARDIR\n" +
+    public static void main(String[] args) throws IOException, LexException {
+	String usage = "java opennlp.ccg.WebCCG " +
+"[-prompt SIGN] [-showall] [-showderivs] [-showsem] [-showfeats] [-visualize FILE] GRAMMARDIR\n" +
 "\n" +
+"-prompt specify a prompt sign (defaults to the empty string).\n" +
 "-showall shows all parses rather than just the first one.\n" +
 "-showderivs shows the derivation history of each parse.\n" +
 "-showsem shows the logical form of each parse.\n" +
@@ -73,6 +74,7 @@ public class WebCCG {
 
 	// args        
 	//String prefsfile = null;
+	String prompt = "";
 	boolean showall = false;
 	boolean showderivs = false;
 	boolean showsem = false;
@@ -80,7 +82,9 @@ public class WebCCG {
 	String visfile = null;
 	int i;
 	for (i = 0; i < args.length; i++) {
-	    if (args[i].equals("-showall"))
+		if (args[i].equals("-prompt"))
+		prompt = args[++i];
+	    else if (args[i].equals("-showall"))
 		showall = true;
 	    else if (args[i].equals("-showderivs"))
 		showderivs = true;
@@ -113,6 +117,8 @@ public class WebCCG {
 
 	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 	while (true) {
+        if ("" != prompt)
+	    System.out.print(prompt + " ");
 	    String input = br.readLine();
 	    if (input == null) break; // EOF
 	    input = input.trim();


### PR DESCRIPTION
Adding -prompt flag to WebCCG to allow tools like Python's pexpect to parse it more easily.

Specifying the prompt flag `wccg -prompt ">>>" GRAMMAR` will case wccg to show the prompt expecting input like this:
```bash
>>> 
```

Entering a sentence looks thus:
```plain
>>> she sings a song
```

By default, the old behavior is kept stable (no prompt sign at all). 

I use this feature to parse the output using [replwrap](https://pexpect.readthedocs.io/en/stable/api/replwrap.html), to keep a process alive for a longer time (before I used [Popen.communicate](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate), which is a one-off command and forced me to create new wccg processes for each parse).

To keep the diff small, I tried to keep the whitespace as it is in the surroundings, but the file mixes tabs and spaces a lot and it seems in lines 85 and 120/121 I somehow missed the conventions a little bit, as I just realized. 
If you want, I can update my lines or reindent the file completely.
