### PR TITLE
add Dockerfile for automated build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+from ubuntu:16.04
+
+# install dependencies
+RUN apt-get update && \
+    apt-get install -y default-jdk ant maven python2.7 graphviz \
+        jam libboost-all-dev zlib1g-dev gfortran g++ make \
+        git wget
+
+# set up all the environment variables
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
+    OPENCCG_HOME="/openccg" \
+    ANT_HOME="/usr/share/ant"
+ENV PATH="$PATH:$OPENCCG_HOME/bin"
+ENV PATH="$PATH:$ANT_HOME/bin"
+ENV PATH="$PATH:/maxent/src/opt"
+
+COPY . ./openccg
+
+WORKDIR /openccg
+
+# optionally build models if they are present
+RUN ./models.sh && \
+#    # set up all the jar dependencies
+    mvn dependency:copy-dependencies -DoutputDirectory='./lib' && \
+    # set up stanford core nlp dependencies
+    mv lib/stanford-corenlp-3.9.2.jar ccgbank/stanford-nlp/stanford-core-nlp.jar && \
+    jar xf lib/stanford-corenlp-3.9.2-models.jar && \
+    cp edu/stanford/nlp/models/ner/* ccgbank/stanford-nlp/classifiers/ && \
+    rm -rf edu && \
+    # set up the project
+    ccg-build
+
+#    # set up the maxent toolkit
+#WORKDIR /usr/share
+#
+#RUN git clone https://github.com/lzhang10/maxent
+#
+#WORKDIR /usr/share/maxent
+#
+#RUN ./configure && make && make install
+
+#    # set up the srilm tools
+#WORKDIR /usr/share
+#
+#RUN wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/moses-suite/srilm-1.6.0.simple.tar.gz && \
+#    tar xzf srilm-1.6.0.simple.tar.gz && \
+#    cd srilm-1.6.0 && \
+#    # set the path to SRILM
+#    sed -i "s/# SRILM =.*/SRILM = \/usr\/share\/srilm-1.6.0/" Makefile && \
+#    # for 64 bit systems
+#    make MACHINE_TYPE=i686-m64
+#    # for 32 bit systems (not tested, but might work)
+#    #make MACHINE_TYPE=i686
+
+#WORKDIR /openccg
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,77 @@ The Eclipse IDE can be used for editing the Java source code, though setup can b
 
 Note that with Eclipse's default settings, the code will compile in your Eclipse workspace, which is separate from your OpenCCG installation (this is a good thing, as Eclipse uses a `bin/` directory for compiled Java classes, whereas OpenCCG uses `bin/` for command-line scripts).  Thus, once you have made a round of changes in Eclipse and are ready to try them out in OpenCCG, go back to the command line in `$OPENCCG_HOME` and invoke `ccg-build` to re-build the `openccg.jar` file. This will make your changes available in OpenCCG's programs, such as `tccg`.
 
+# Running locally with Docker
+
+Alternately, if you would prefer using Docker rather than
+configuring and building everything yourself, that's also possible.
+
+## Installation
+
+* Installing docker for Windows
+
+For instructions on how to install docker for Windows 10, go
+[here](https://docs.docker.com/docker-for-windows/install/),
+or for slightly older Windows computers,
+go [here](https://docs.docker.com/toolbox/overview/).
+
+* Installing docker for MacOS
+
+For instructions on how to install docker for MacOS (at
+least El Capitan 10.11), go
+[here](https://docs.docker.com/docker-for-mac/install/),
+or for slightly older MacOS computers,
+go [here](https://docs.docker.com/toolbox/overview/)
+
+* Installing docker on Linux
+
+For instructions on how to install docker for Ubuntu (at
+least 14.04), go [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/). This link also has options for other
+Linux distributions.
+
+
+to test your installation, just type:
+`docker --version`
+at the terminal/command prompt
+
+A successful install will result in something that looks like:
+`Docker version 17.05.0-ce, build 89658be`
+
+## Running in a container
+
+Once you have docker up and running, the following command will
+help you build from the Dockerfile:
+`docker build -t YOUR_TAG_HERE .`
+(the tag is so it's easy to reference later)
+
+After the container is finished building, you can run it with:
+`docker run -it --rm -t YOUR_TAG_HERE`
+
+When you're finished just type `exit` to leave the container.
+
+## Functionality in the container
+
+The following functions should work immediately once the container is built:
+
+- tccg command line tool
+- visualizing the semantic graphs
+- parsing
+- realization
+
+If you want to use the pre-built statistical models (referenced as `english-models.YYYY-MM-DD.tgz` in `docs/ccgbank-README`), just follow the instructions there and be sure to copy the renamed file (eg, `english-models.tgz`) into the `ccgbank` directory locally, then build the container and `models.sh` will automatically extract it for you.
+
+If you want to use the tagging capabilities listed in
+`docs/taggers-README` utilizing the Maxent toolkit and SRILM,
+uncomment those lines in the `Dockerfile`, and build as normal.
+
+---
+
+The following functions are not currently set up by default inside the container:
+
+- building the English models from the CCGBank
+(the CCGBank is licensed, and so dealing with it hasn't been included in this public docker image)
+
+
 # Bug Reports
 
 Please report bugs at by creating [an issue with a description of the problem](https://github.com/OpenCCG/openccg/issues). 

--- a/models.sh
+++ b/models.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+FILE=/openccg/ccgbank/english-models.tgz
+
+if [ -f "$FILE" ]; then
+  ccg-build -f ccgbank/build-release.xml extract-models
+else
+  echo "$FILE does not exist, skipping this step"
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>openccg</groupId>
+  <artifactId>openccg</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <dependencies>
+
+    <dependency>
+        <groupId>ant-contrib</groupId>
+        <artifactId>ant-contrib</artifactId>
+        <version>1.0b3</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom</artifactId>
+        <version>1.1</version>
+    </dependency>
+
+    <dependency>
+        <groupId>net.sf.jgrapht</groupId>
+        <artifactId>jgrapht</artifactId>
+        <version>0.8.3</version>
+    </dependency>
+
+    <dependency>
+        <groupId>jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>1.0</version>
+    </dependency>
+
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.10</version>
+        <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+        <groupId>trove</groupId>
+        <artifactId>trove</artifactId>
+        <version>1.0.2</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <version>2.7.1</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.9.0</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.0.b2</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>serializer</artifactId>
+        <version>2.7.1</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>net.sf.jopt-simple</groupId>
+        <artifactId>jopt-simple</artifactId>
+        <version>3.1</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>net.java.dev.javacc</groupId>
+        <artifactId>javacc</artifactId>
+        <version>4.0</version>
+    </dependency>
+
+    <dependency>
+        <groupId>edu.stanford.nlp</groupId>
+        <artifactId>stanford-corenlp</artifactId>
+        <version>3.9.2</version>
+    </dependency>
+
+    <dependency>
+        <groupId>edu.stanford.nlp</groupId>
+        <artifactId>stanford-corenlp</artifactId>
+        <version>3.9.2</version>
+        <classifier>models</classifier>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <directory>lib</directory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <outputDirectory>
+            ${project.build.directory}
+          </outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
I'm not exactly sure why, but when I tried to use line continuation to put all the ENV variable declarations on one line, everything blew up...so leaving it as multiple layers for now. I've also not had much luck building things in the smaller alpine containers, so that's why I went with the bigger (but more robust) ubuntu 16.04 base image.

Ideally, we would have a Dockerfile that features a clean build with everything in source control, but if that's not feasible, then I suggest we might use this to put something in a publicly accessible docker hub image, to be used with docker-compose, and then it wouldn't have to constantly pull in dependencies from sourceforge.

I also only did cursory testing on this (ie, with the tccg command in /grammars/tiny), so there might be something I missed during the compilation process, but happy to update this PR in that event.

Lastly, if it seems sensible to add in a short section in the README about installing docker, running it as non-root (at least in linux), and using it to build and run the image, I'm happy to add that as part of this PR as well.